### PR TITLE
Move certain dependencies to devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,12 +2,22 @@
   "name": "eosvotes",
   "license": "UNLICENSED",
   "scripts": {
-    "start": "./node_modules/webpack-dev-server/bin/webpack-dev-server.js --hot --mode development",
-    "build": "./node_modules/webpack/bin/webpack.js --mode production",
+    "start": "webpack-dev-server --hot --mode development",
+    "build": "webpack --mode production",
     "postinstall": "cp .env.example .env",
     "test": "exit 0"
   },
   "dependencies": {
+    "foundation-sites": "^6.4.3",
+    "hammerjs": "^2.0.8",
+    "react": "^16.0.0",
+    "react-dom": "^16.0.0",
+    "react-router-dom": "^4.1.2",
+    "react-templates": "^0.6.3",
+    "reset-css": "^2.2.1",
+    "whatwg-fetch": "^2.0.4"
+  },
+  "devDependencies": {
     "autoprefixer": "^6.7.7",
     "babel-core": "^6.26.0",
     "babel-loader": "^7.1.4",
@@ -18,28 +28,18 @@
     "dotenv-webpack": "^1.5.7",
     "extract-loader": "^2.0.1",
     "file-loader": "^1.1.11",
-    "foundation-sites": "^6.4.3",
-    "hammerjs": "^2.0.8",
     "html-loader": "^0.5.5",
-    "node-sass": "^3.13.1",
+    "node-sass": "^4.9.3",
     "postcss-loader": "^2.1.1",
     "promise-polyfill": "^8.1.0",
     "raw-loader": "^0.5.1",
-    "react": "^16.0.0",
-    "react-dom": "^16.0.0",
-    "react-router-dom": "^4.1.2",
-    "react-templates": "^0.6.3",
     "react-templates-loader": "^0.6.5",
-    "reset-css": "^2.2.1",
     "sass-loader": "^6.0.7",
     "style-loader": "^0.21.0",
     "url-loader": "^1.0.1",
     "webfonts-loader": "^4.0.1",
     "webpack": "^4.6.0",
     "webpack-cli": "^2.0.14",
-    "whatwg-fetch": "^2.0.4"
-  },
-  "devDependencies": {
     "webpack-dev-server": "^3.1.3"
   }
 }


### PR DESCRIPTION
`dependencies`:
What is used in your source code (eg: React)

`devDependencies`:
What is used to "build" your source code (eg: Babel, Webpack, etc...)

`scripts`:
You no longer need to reference the full `node_modules` filepath, NodeJS will automatically detect the executables