### PR TITLE
Add EOS Votes tally into dummy folder

### DIFF
--- a/dummy/proposals/latest.json
+++ b/dummy/proposals/latest.json
@@ -1,0 +1,32 @@
+{
+	"eoscanadacom:havefunornot": {
+		"proposer": "eoscanadacom",
+		"proposal_name": "havefunornot",
+		"title": "The fun dilemma",
+		"proposal_json": {
+			"type": "bps-proposal-v1",
+			"content": "# The question\n\nShould we have fun?\n\n# The context\n\nIt's all about fun, all around the world, at the same time.\n\n# The vote\n\nAnswering `true` means we should have fun, answering `false` means we should *not* have fun.\n\nFor your vote to be valid, you must include a SHA-256 hash of the `title` concatenated with the `proposal_json` of this proposal.\n\n# The tally\n\nVotes will be tallied according to the principle of Archimedes, which will be tweaked until it makes sense.\n\n# The timing\n\nThe voting period ends at block 8,000,000 (inclusively). Any votes cast after that will not be counted. You also need to fill in the whole circle with your pen.\n"
+		}
+	},
+	"aus1genereos:aretoolsredy": {
+		"proposer": "aus1genereos",
+		"proposal_name": "aretoolsredy",
+		"title": "Are tools ready for everyone to use?",
+		"proposal_json": {}
+	},
+	"gy2dcmbuhege:nuevogato": {
+		"proposer": "gy2dcmbuhege",
+		"proposal_name": "nuevogato",
+		"title": "Se busca comprar un gato",
+		"proposal_json": {
+			"type": "bps-proposal-v1",
+			"content": "Un gato para la casa que haga todos los mandados"
+		}
+	},
+	"eostribeprod:bpminpayment": {
+		"proposer": "eostribeprod",
+		"proposal_name": "bpminpayment",
+		"title": "Do you support proposal to lower minimal BP payout threshold to 50 EOS per day?",
+		"proposal_json": {}
+	}
+}

--- a/dummy/tally/latest.json
+++ b/dummy/tally/latest.json
@@ -1,0 +1,66 @@
+{
+	"eoscanadacom:havefunornot": {
+		"active": true,
+		"blockNumber": 10188788,
+		"blockHash": "009b77f49b78ae40cd8c48462a931794a56fb8df7ab327ded343bb1c0bc572c6",
+		"firstBlockNumber": 7813567,
+		"firstBlockHash": "007739bf1c712721c79778a87f14e247aea13cccf7a8391f350b5230390d590e",
+		"votes": {
+			"0": 1,
+			"1": 2
+		},
+		"staked": {
+			"0": 14000,
+			"1": 390588
+		},
+		"last_vote_weight": {
+			"0": 5774245738.283412,
+			"1": 171618709929.0255
+		}
+	},
+	"aus1genereos:aretoolsredy": {
+		"active": true,
+		"blockNumber": 8554735,
+		"blockHash": "008288eff8f9da5142d74642273f831214b272f6b3c994258943231186a2a9ac",
+		"firstBlockNumber": 8554735,
+		"firstBlockHash": "008288eff8f9da5142d74642273f831214b272f6b3c994258943231186a2a9ac",
+		"votes": {},
+		"staked": {},
+		"last_vote_weight": {}
+	},
+	"gy2dcmbuhege:nuevogato": {
+		"active": true,
+		"blockNumber": 10188788,
+		"blockHash": "009b77f49b78ae40cd8c48462a931794a56fb8df7ab327ded343bb1c0bc572c6",
+		"firstBlockNumber": 9179364,
+		"firstBlockHash": "008c10e4753989af5f4e72396a576943d6a09f3572f3583d8fc537f2a14d7fa2",
+		"votes": {
+			"1": 1
+		},
+		"staked": {
+			"1": 246000
+		},
+		"last_vote_weight": {
+			"1": 102823260777.27234
+		}
+	},
+	"eostribeprod:bpminpayment": {
+		"active": true,
+		"blockNumber": 10188788,
+		"blockHash": "009b77f49b78ae40cd8c48462a931794a56fb8df7ab327ded343bb1c0bc572c6",
+		"firstBlockNumber": 9304570,
+		"firstBlockHash": "008df9fa103a5e0955085279af2df996d2d1cdb82c443eed8b016687a334ee4a",
+		"votes": {
+			"0": 8,
+			"1": 12
+		},
+		"staked": {
+			"0": 270956135,
+			"1": 762143235
+		},
+		"last_vote_weight": {
+			"0": 111622798625499.17,
+			"1": 313973592530119.7
+		}
+	}
+}

--- a/dummy/voters/latest.json
+++ b/dummy/voters/latest.json
@@ -1,0 +1,763 @@
+{
+	"aus1genereos": {
+		"owner": "aus1genereos",
+		"proxy": "",
+		"producers": [
+			"aus1genereos"
+		],
+		"staked": 380000,
+		"last_vote_weight": "167193129908.25411987304687500",
+		"proxied_vote_weight": "8360450658.80903816223144531",
+		"is_proxy": 1,
+		"proposals": {
+			"eoscanadacom:havefunornot": {
+				"voter": "aus1genereos",
+				"proposer": "eoscanadacom",
+				"proposal_name": "havefunornot",
+				"proposal_hash": "e4b00c58d12cc674209861f7cca95f47ad8e7a9c435d4e166f7ac2dbcf5dc05d",
+				"vote": 1,
+				"vote_json": {}
+			}
+		}
+	},
+	"gy2dcmbuhege": {
+		"owner": "gy2dcmbuhege",
+		"proxy": "ovallesergio",
+		"producers": [],
+		"staked": 246000,
+		"last_vote_weight": "102823260777.27233886718750000",
+		"proxied_vote_weight": "0.00000000000000000",
+		"is_proxy": 0,
+		"proposals": {
+			"gy2dcmbuhege:nuevogato": {
+				"voter": "gy2dcmbuhege",
+				"proposer": "gy2dcmbuhege",
+				"proposal_name": "nuevogato",
+				"proposal_hash": "b5c828b18e09355f95ee7d1b80db3ecf71c15d7d9af2d90832f5c77971b36724",
+				"vote": 1,
+				"vote_json": {}
+			}
+		}
+	},
+	"dexteryy5555": {
+		"owner": "dexteryy5555",
+		"proxy": "",
+		"producers": [
+			"argentinaeos",
+			"aus1genereos",
+			"cryptolions1",
+			"cypherglasss",
+			"eos42freedom",
+			"eosafricaone",
+			"eosamsterdam",
+			"eosasia11111",
+			"eosauthority",
+			"eosbixinboot",
+			"eoscanadacom",
+			"eosdublinwow",
+			"eosfishrocks",
+			"eosgenblockp",
+			"eoshuobipool",
+			"eosiomeetone",
+			"eosisgravity",
+			"eosmedinodes",
+			"eosnairobike",
+			"eosnationftw",
+			"eosnewyorkio",
+			"eosphereiobp",
+			"eosriobrazil",
+			"eosswedenorg",
+			"eostitanprod",
+			"eostribeprod",
+			"jedaaaaaaaaa",
+			"libertyblock",
+			"moreisfuture",
+			"teamgreymass"
+		],
+		"staked": 14000,
+		"last_vote_weight": "5774245738.28341197967529297",
+		"proxied_vote_weight": "0.00000000000000000",
+		"is_proxy": 0,
+		"proposals": {
+			"eoscanadacom:havefunornot": {
+				"voter": "dexteryy5555",
+				"proposer": "eoscanadacom",
+				"proposal_name": "havefunornot",
+				"proposal_hash": "e4b00c58d12cc674209861f7cca95f47ad8e7a9c435d4e166f7ac2dbcf5dc05d",
+				"vote": 0,
+				"vote_json": {}
+			}
+		}
+	},
+	"dexteryy5551": {
+		"owner": "dexteryy5551",
+		"proxy": "",
+		"producers": [
+			"eosasia11111"
+		],
+		"staked": 10588,
+		"last_vote_weight": "4425580020.77138042449951172",
+		"proxied_vote_weight": "0.00000000000000000",
+		"is_proxy": 0,
+		"proposals": {
+			"eoscanadacom:havefunornot": {
+				"voter": "dexteryy5551",
+				"proposer": "eoscanadacom",
+				"proposal_name": "havefunornot",
+				"proposal_hash": "e4b00c58d12cc674209861f7cca95f47ad8e7a9c435d4e166f7ac2dbcf5dc05d",
+				"vote": 1,
+				"vote_json": {}
+			}
+		}
+	},
+	"eostribeprod": {
+		"owner": "eostribeprod",
+		"proxy": "",
+		"producers": [],
+		"staked": 220000,
+		"last_vote_weight": "0.00000000000000000",
+		"proxied_vote_weight": "0.00000000000000000",
+		"is_proxy": 0,
+		"proposals": {
+			"eostribeprod:bpminpayment": {
+				"voter": "eostribeprod",
+				"proposer": "eostribeprod",
+				"proposal_name": "bpminpayment",
+				"proposal_hash": "0c3b4f41b925682c5e08ae429fd5836527bb84564ed48e292c2ae7c5a441f01f",
+				"vote": 1,
+				"vote_json": {}
+			}
+		}
+	},
+	"gmzdombwguge": {
+		"owner": "gmzdombwguge",
+		"proxy": "detroitproxy",
+		"producers": [],
+		"staked": 360009113,
+		"last_vote_weight": "146518236467893.09375000000000000",
+		"proxied_vote_weight": "0.00000000000000000",
+		"is_proxy": 0,
+		"proposals": {
+			"eostribeprod:bpminpayment": {
+				"voter": "gmzdombwguge",
+				"proposer": "eostribeprod",
+				"proposal_name": "bpminpayment",
+				"proposal_hash": "0c3b4f41b925682c5e08ae429fd5836527bb84564ed48e292c2ae7c5a441f01f",
+				"vote": 1,
+				"vote_json": {}
+			}
+		}
+	},
+	"gmytqobsgege": {
+		"owner": "gmytqobsgege",
+		"proxy": "",
+		"producers": [
+			"alohaeosprod",
+			"argentinaeos",
+			"aus1genereos",
+			"blocksmithio",
+			"costaricaeos",
+			"cryptolions1",
+			"cypherglasss",
+			"eos42freedom",
+			"eosamsterdam",
+			"eosauthority",
+			"eoscafeblock",
+			"eoscanadacom",
+			"eosdacserver",
+			"eosdublinwow",
+			"eosfishrocks",
+			"eosflareiobp",
+			"eosiodetroit",
+			"eosiomeetone",
+			"eosisgravity",
+			"eosmesodotio",
+			"eosnationftw",
+			"eosnewyorkio",
+			"eosriobrazil",
+			"eosswedenorg",
+			"eostribeprod",
+			"eosvibesbloc",
+			"hkeoshkeosbp",
+			"libertyblock",
+			"teamgreymass",
+			"tokenika4eos"
+		],
+		"staked": 15291563,
+		"last_vote_weight": "6991938322462.53027343750000000",
+		"proxied_vote_weight": "514591046795.97058105468750000",
+		"is_proxy": 1,
+		"proposals": {
+			"eostribeprod:bpminpayment": {
+				"voter": "gmytqobsgege",
+				"proposer": "eostribeprod",
+				"proposal_name": "bpminpayment",
+				"proposal_hash": "0c3b4f41b925682c5e08ae429fd5836527bb84564ed48e292c2ae7c5a441f01f",
+				"vote": 1,
+				"vote_json": {}
+			}
+		}
+	},
+	"gy4dqmrrgene": {
+		"owner": "gy4dqmrrgene",
+		"proxy": "",
+		"producers": [
+			"argentinaeos",
+			"aus1genereos",
+			"blockgenicbp",
+			"blocksmithio",
+			"buildteameos",
+			"cryptolions1",
+			"cypherglasss",
+			"eosauthority",
+			"eoscanadacom",
+			"eoscannonchn",
+			"eosdacserver",
+			"eoseouldotio",
+			"eosflareiobp",
+			"eosiomeetone",
+			"eosliquideos",
+			"eosmetaliobp",
+			"eosnairobike",
+			"eosnationftw",
+			"eosnewyorkio",
+			"eosphereiobp",
+			"eosriobrazil",
+			"eossocalprod",
+			"eostribeprod",
+			"eosvenezuela",
+			"eosvibesbloc",
+			"eosyskoreabp",
+			"libertyblock",
+			"sheos21sheos",
+			"teamgreymass",
+			"unlimitedeos"
+		],
+		"staked": 1160200,
+		"last_vote_weight": "902850808783.51855468750000000",
+		"proxied_vote_weight": "411402138086.58959960937500000",
+		"is_proxy": 1,
+		"proposals": {
+			"eostribeprod:bpminpayment": {
+				"voter": "gy4dqmrrgene",
+				"proposer": "eostribeprod",
+				"proposal_name": "bpminpayment",
+				"proposal_hash": "0c3b4f41b925682c5e08ae429fd5836527bb84564ed48e292c2ae7c5a441f01f",
+				"vote": 1,
+				"vote_json": {}
+			}
+		}
+	},
+	"geytamrzhege": {
+		"owner": "geytamrzhege",
+		"proxy": "",
+		"producers": [
+			"eosasia11111",
+			"eoscanadacom",
+			"eosnewyorkio",
+			"eosriobrazil",
+			"eosswedenorg"
+		],
+		"staked": 8312,
+		"last_vote_weight": "3520876875.39465045928955078",
+		"proxied_vote_weight": "0.00000000000000000",
+		"is_proxy": 0,
+		"proposals": {
+			"eostribeprod:bpminpayment": {
+				"voter": "geytamrzhege",
+				"proposer": "eostribeprod",
+				"proposal_name": "bpminpayment",
+				"proposal_hash": "0c3b4f41b925682c5e08ae429fd5836527bb84564ed48e292c2ae7c5a441f01f",
+				"vote": 0,
+				"vote_json": {}
+			}
+		}
+	},
+	"gyztqojug4ge": {
+		"owner": "gyztqojug4ge",
+		"proxy": "",
+		"producers": [
+			"aus1genereos"
+		],
+		"staked": 15000,
+		"last_vote_weight": "6186691862.44651222229003906",
+		"proxied_vote_weight": "0.00000000000000000",
+		"is_proxy": 0,
+		"proposals": {
+			"eostribeprod:bpminpayment": {
+				"voter": "gyztqojug4ge",
+				"proposer": "eostribeprod",
+				"proposal_name": "bpminpayment",
+				"proposal_hash": "0c3b4f41b925682c5e08ae429fd5836527bb84564ed48e292c2ae7c5a441f01f",
+				"vote": 1,
+				"vote_json": {}
+			}
+		}
+	},
+	"gi2dknrygege": {
+		"owner": "gi2dknrygege",
+		"proxy": "",
+		"producers": [
+			"aus1genereos",
+			"bitfinexeos1",
+			"cryptolions1",
+			"eos42freedom",
+			"eosafricaone",
+			"eosasia11111",
+			"eosauthority",
+			"eoscafeblock",
+			"eoscanadacom",
+			"eoscannonchn",
+			"eosdacserver",
+			"eosdublinwow",
+			"eosflareiobp",
+			"eosisgravity",
+			"eosliquideos",
+			"eosmesodotio",
+			"eosmetaliobp",
+			"eosnewyorkio",
+			"eosnodeonebp",
+			"eosonoeosono",
+			"eosrealbpcsg",
+			"eosriobrazil",
+			"eossv12eossv",
+			"eosswedenorg",
+			"eosvenezuela",
+			"eosyskoreabp",
+			"philippinebp",
+			"teamgreymass"
+		],
+		"staked": 3023647,
+		"last_vote_weight": "1280785466994.27441406250000000",
+		"proxied_vote_weight": "0.00000000000000000",
+		"is_proxy": 0,
+		"proposals": {
+			"eostribeprod:bpminpayment": {
+				"voter": "gi2dknrygege",
+				"proposer": "eostribeprod",
+				"proposal_name": "bpminpayment",
+				"proposal_hash": "0c3b4f41b925682c5e08ae429fd5836527bb84564ed48e292c2ae7c5a441f01f",
+				"vote": 0,
+				"vote_json": {}
+			}
+		}
+	},
+	"gy2tcobqgyge": {
+		"owner": "gy2tcobqgyge",
+		"proxy": "",
+		"producers": [
+			"cryptolions1",
+			"eosasia11111",
+			"eosauthority",
+			"eoscanadacom",
+			"eosdacserver",
+			"eoseouldotio",
+			"eosisgravity",
+			"eosnewyorkio",
+			"sheos21sheos"
+		],
+		"staked": 34978485,
+		"last_vote_weight": "12967489798999.60351562500000000",
+		"proxied_vote_weight": "0.00000000000000000",
+		"is_proxy": 0,
+		"proposals": {
+			"eostribeprod:bpminpayment": {
+				"voter": "gy2tcobqgyge",
+				"proposer": "eostribeprod",
+				"proposal_name": "bpminpayment",
+				"proposal_hash": "0c3b4f41b925682c5e08ae429fd5836527bb84564ed48e292c2ae7c5a441f01f",
+				"vote": 1,
+				"vote_json": {}
+			}
+		}
+	},
+	"g44dknbqgene": {
+		"owner": "g44dknbqgene",
+		"proxy": "",
+		"producers": [
+			"argentinaeos",
+			"aus1genereos",
+			"blocksmithio",
+			"cryptolions1",
+			"cypherglasss",
+			"eosauthority",
+			"eoscafeblock",
+			"eoscanadacom",
+			"eosdacserver",
+			"eosdublinwow",
+			"eosiomeetone",
+			"eosisgravity",
+			"eosliquideos",
+			"eosnewyorkio",
+			"eosnodeonebp",
+			"eosriobrazil",
+			"eosswedenorg",
+			"eostribeprod",
+			"eosyskoreabp",
+			"libertyblock",
+			"sheos21sheos",
+			"teamgreymass",
+			"tokenika4eos"
+		],
+		"staked": 18171649,
+		"last_vote_weight": "7697321794019.28808593750000000",
+		"proxied_vote_weight": "0.00000000000000000",
+		"is_proxy": 0,
+		"proposals": {
+			"eostribeprod:bpminpayment": {
+				"voter": "g44dknbqgene",
+				"proposer": "eostribeprod",
+				"proposal_name": "bpminpayment",
+				"proposal_hash": "0c3b4f41b925682c5e08ae429fd5836527bb84564ed48e292c2ae7c5a441f01f",
+				"vote": 1,
+				"vote_json": {}
+			}
+		}
+	},
+	"eostokendrop": {
+		"owner": "eostokendrop",
+		"proxy": "",
+		"producers": [],
+		"staked": 22000,
+		"last_vote_weight": "0.00000000000000000",
+		"proxied_vote_weight": "0.00000000000000000",
+		"is_proxy": 0,
+		"proposals": {
+			"eostribeprod:bpminpayment": {
+				"voter": "eostokendrop",
+				"proposer": "eostribeprod",
+				"proposal_name": "bpminpayment",
+				"proposal_hash": "0c3b4f41b925682c5e08ae429fd5836527bb84564ed48e292c2ae7c5a441f01f",
+				"vote": 0,
+				"vote_json": {}
+			}
+		}
+	},
+	"hodlwaitfire": {
+		"owner": "hodlwaitfire",
+		"proxy": "eosnproxvote",
+		"producers": [],
+		"staked": 249984000,
+		"last_vote_weight": "103104931902788.60937500000000000",
+		"proxied_vote_weight": "0.00000000000000000",
+		"is_proxy": 0,
+		"proposals": {
+			"eostribeprod:bpminpayment": {
+				"voter": "hodlwaitfire",
+				"proposer": "eostribeprod",
+				"proposal_name": "bpminpayment",
+				"proposal_hash": "0c3b4f41b925682c5e08ae429fd5836527bb84564ed48e292c2ae7c5a441f01f",
+				"vote": 0,
+				"vote_json": {}
+			}
+		}
+	},
+	"ge3tsobugige": {
+		"owner": "ge3tsobugige",
+		"proxy": "",
+		"producers": [
+			"argentinaeos",
+			"aus1genereos",
+			"blocksmithio",
+			"cryptolions1",
+			"cypherglasss",
+			"eos42freedom",
+			"eosafricaone",
+			"eosauthority",
+			"eoscafeblock",
+			"eoscanadacom",
+			"eosdacserver",
+			"eosdublinwow",
+			"eosflareiobp",
+			"eosmesodotio",
+			"eosnationftw",
+			"eosnewyorkio",
+			"eosnodeonebp",
+			"eosriobrazil",
+			"eosvenezuela",
+			"hkeoshkeosbp",
+			"jedaaaaaaaaa",
+			"teamgreymass"
+		],
+		"staked": 500000,
+		"last_vote_weight": "208990367433.48037719726562500",
+		"proxied_vote_weight": "0.00000000000000000",
+		"is_proxy": 0,
+		"proposals": {
+			"eostribeprod:bpminpayment": {
+				"voter": "ge3tsobugige",
+				"proposer": "eostribeprod",
+				"proposal_name": "bpminpayment",
+				"proposal_hash": "0c3b4f41b925682c5e08ae429fd5836527bb84564ed48e292c2ae7c5a441f01f",
+				"vote": 1,
+				"vote_json": {}
+			}
+		}
+	},
+	"gq2tsnjqgqge": {
+		"owner": "gq2tsnjqgqge",
+		"proxy": "",
+		"producers": [
+			"argentinaeos",
+			"aus1genereos",
+			"blocksmithio",
+			"cryptolions1",
+			"eosamsterdam",
+			"eosasia11111",
+			"eoscafeblock",
+			"eoscanadacom",
+			"eosdublinwow",
+			"eosnewyorkio",
+			"eosriobrazil",
+			"eosswedenorg",
+			"eostribeprod",
+			"hkeoshkeosbp",
+			"sheos21sheos",
+			"teamgreymass",
+			"tokenika4eos"
+		],
+		"staked": 106177,
+		"last_vote_weight": "40968728478.94014739990234375",
+		"proxied_vote_weight": "0.00000000000000000",
+		"is_proxy": 0,
+		"proposals": {
+			"eostribeprod:bpminpayment": {
+				"voter": "gq2tsnjqgqge",
+				"proposer": "eostribeprod",
+				"proposal_name": "bpminpayment",
+				"proposal_hash": "0c3b4f41b925682c5e08ae429fd5836527bb84564ed48e292c2ae7c5a441f01f",
+				"vote": 1,
+				"vote_json": {}
+			}
+		}
+	},
+	"gm3temjvgage": {
+		"owner": "gm3temjvgage",
+		"proxy": "",
+		"producers": [
+			"eosasia11111"
+		],
+		"staked": 6549175,
+		"last_vote_weight": "2665414670543.66943359375000000",
+		"proxied_vote_weight": "0.00000000000000000",
+		"is_proxy": 0,
+		"proposals": {
+			"eostribeprod:bpminpayment": {
+				"voter": "gm3temjvgage",
+				"proposer": "eostribeprod",
+				"proposal_name": "bpminpayment",
+				"proposal_hash": "0c3b4f41b925682c5e08ae429fd5836527bb84564ed48e292c2ae7c5a441f01f",
+				"vote": 0,
+				"vote_json": {}
+			}
+		}
+	},
+	"hezdkojthege": {
+		"owner": "hezdkojthege",
+		"proxy": "goodguys4eos",
+		"producers": [],
+		"staked": 331550848,
+		"last_vote_weight": "138581867092804.00000000000000000",
+		"proxied_vote_weight": "0.00000000000000000",
+		"is_proxy": 0,
+		"proposals": {
+			"eostribeprod:bpminpayment": {
+				"voter": "hezdkojthege",
+				"proposer": "eostribeprod",
+				"proposal_name": "bpminpayment",
+				"proposal_hash": "0c3b4f41b925682c5e08ae429fd5836527bb84564ed48e292c2ae7c5a441f01f",
+				"vote": 1,
+				"vote_json": {}
+			}
+		}
+	},
+	"gq3tcnbzg4ge": {
+		"owner": "gq3tcnbzg4ge",
+		"proxy": "",
+		"producers": [
+			"argentinaeos",
+			"atticlabeosb",
+			"aus1genereos",
+			"blocksmithio",
+			"costaricaeos",
+			"cryptolions1",
+			"emergepoland",
+			"eos42freedom",
+			"eosafricaone",
+			"eosasia11111",
+			"eosauthority",
+			"eoscafeblock",
+			"eoscanadacom",
+			"eosdacserver",
+			"eosdublinwow",
+			"eoseouldotio",
+			"eosgermanybp",
+			"eosiomeetone",
+			"eosliquideos",
+			"eoslovebirds",
+			"eosnairobike",
+			"eosnationftw",
+			"eosphereiobp",
+			"eosriobrazil",
+			"eosromania22",
+			"eosswedenorg",
+			"eosvibesbloc",
+			"libertyblock",
+			"sheos21sheos",
+			"teamgreymass"
+		],
+		"staked": 10070001,
+		"last_vote_weight": "4044069994585.03125000000000000",
+		"proxied_vote_weight": "0.00000000000000000",
+		"is_proxy": 0,
+		"proposals": {
+			"eostribeprod:bpminpayment": {
+				"voter": "gq3tcnbzg4ge",
+				"proposer": "eostribeprod",
+				"proposal_name": "bpminpayment",
+				"proposal_hash": "0c3b4f41b925682c5e08ae429fd5836527bb84564ed48e292c2ae7c5a441f01f",
+				"vote": 0,
+				"vote_json": {}
+			}
+		}
+	},
+	"gq4dmnjzgige": {
+		"owner": "gq4dmnjzgige",
+		"proxy": "",
+		"producers": [
+			"argentinaeos",
+			"aus1genereos",
+			"cryptolions1",
+			"eosamsterdam",
+			"eosauthority",
+			"eoscanadacom",
+			"eosdacserver",
+			"eosimperabpi",
+			"eosnationftw",
+			"eosswedenorg"
+		],
+		"staked": 429000,
+		"last_vote_weight": "179313735257.92614746093750000",
+		"proxied_vote_weight": "0.00000000000000000",
+		"is_proxy": 0,
+		"proposals": {
+			"eostribeprod:bpminpayment": {
+				"voter": "gq4dmnjzgige",
+				"proposer": "eostribeprod",
+				"proposal_name": "bpminpayment",
+				"proposal_hash": "0c3b4f41b925682c5e08ae429fd5836527bb84564ed48e292c2ae7c5a441f01f",
+				"vote": 0,
+				"vote_json": {}
+			}
+		}
+	},
+	"g42tcnbxgage": {
+		"owner": "g42tcnbxgage",
+		"proxy": "",
+		"producers": [
+			"acroeos12345",
+			"aus1genereos",
+			"blocksmithio",
+			"cryptolions1",
+			"eos42freedom",
+			"eosamsterdam",
+			"eosasia11111",
+			"eosauthority",
+			"eosbarcelona",
+			"eoscafeblock",
+			"eoscandyone1",
+			"eosdacserver",
+			"eosdotwikibp",
+			"eosgenblockp",
+			"eosgermanybp",
+			"eosiomeetone",
+			"eosisgravity",
+			"eoslaomaocom",
+			"eosmetaliobp",
+			"eosnationftw",
+			"eosnetworkio",
+			"eosonoeosono",
+			"eosriobrazil",
+			"eossocalprod",
+			"eosswedenorg",
+			"eosvancouver",
+			"eosyskoreabp",
+			"jedaaaaaaaaa",
+			"libertyblock",
+			"teamgreymass"
+		],
+		"staked": 140000,
+		"last_vote_weight": "57742457382.83412170410156250",
+		"proxied_vote_weight": "0.00000000000000000",
+		"is_proxy": 0,
+		"proposals": {
+			"eostribeprod:bpminpayment": {
+				"voter": "g42tcnbxgage",
+				"proposer": "eostribeprod",
+				"proposal_name": "bpminpayment",
+				"proposal_hash": "0c3b4f41b925682c5e08ae429fd5836527bb84564ed48e292c2ae7c5a441f01f",
+				"vote": 1,
+				"vote_json": {}
+			}
+		}
+	},
+	"tradexchange": {
+		"owner": "tradexchange",
+		"proxy": "",
+		"producers": [],
+		"staked": 200,
+		"last_vote_weight": "0.00000000000000000",
+		"proxied_vote_weight": "0.00000000000000000",
+		"is_proxy": 0,
+		"proposals": {
+			"eostribeprod:bpminpayment": {
+				"voter": "tradexchange",
+				"proposer": "eostribeprod",
+				"proposal_name": "bpminpayment",
+				"proposal_hash": "0c3b4f41b925682c5e08ae429fd5836527bb84564ed48e292c2ae7c5a441f01f",
+				"vote": 1,
+				"vote_json": {}
+			}
+		}
+	},
+	"eosmarc12345": {
+		"owner": "eosmarc12345",
+		"proxy": "",
+		"producers": [
+			"argentinaeos",
+			"cryptolions1",
+			"cypherglasss",
+			"eosamsterdam",
+			"eosauthority",
+			"eoscafeblock",
+			"eoscanadacom",
+			"eosdacserver",
+			"eosliquideos",
+			"eosnationftw",
+			"eosnewyorkio",
+			"eosonoeosono",
+			"eosphereiobp",
+			"eosriobrazil",
+			"eosswedenorg",
+			"eostribeprod",
+			"eosvenezuela",
+			"jedaaaaaaaaa",
+			"libertyblock",
+			"teamgreymass"
+		],
+		"staked": 870000,
+		"last_vote_weight": "344761978454.26574707031250000",
+		"proxied_vote_weight": "0.00000000000000000",
+		"is_proxy": 0,
+		"proposals": {
+			"eostribeprod:bpminpayment": {
+				"voter": "eosmarc12345",
+				"proposer": "eostribeprod",
+				"proposal_name": "bpminpayment",
+				"proposal_hash": "0c3b4f41b925682c5e08ae429fd5836527bb84564ed48e292c2ae7c5a441f01f",
+				"vote": 0,
+				"vote_json": {}
+			}
+		}
+	}
+}


### PR DESCRIPTION
Here is the schema of the State =>
https://github.com/EOS-Nation/eosvotes-demux-tally/tree/master/types/state

**AWS File Schema (Proposed)**

The Frontend UI can always be pointing to the `latest.json` of each JSON dump.

**voters**
- `s3://api.eosvotes.io/voters/latest.json`
- `s3://api.eosvotes.io/voters/eosvotes-voters-<BlockNumber>.json`

**proposals**
- `s3://api.eosvotes.io/proposals/latest.json`
- `s3://api.eosvotes.io/proposals/eosvotes-proposals-<BlockNumber>.json`

**tally**
- `s3://api.eosvotes.io/tally/latest.json`
- `s3://api.eosvotes.io/tally/eosvotes-tally-<BlockNumber>.json`

**Typescript Definition for Tally**

```ts
export interface Tally {
    /**
     * Proposal active or not
     */
    active: boolean;
    /**
     * total amount of votes
     */
    votes: {
        [vote: number]: number
    },
    /**
     * total `staked` votes (divide by 10000 for EOS precision)
     */
    staked: {
        [vote: number]: number
    },
    /**
     * total `last_vote_weight` votes
     */
    last_vote_weight: {
        [vote: number]: number
    },
    /**
     * Last Block Number
     */
    blockNumber: number
    /**
     * Last Block Hash
     */
    blockHash: string
    /**
     * First Block Number
     */
    firstBlockNumber: number
    /**
     * First Block Hash
     */
    firstBlockHash: string
}
```